### PR TITLE
go.mod: change package name to github.uri

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module fack
+module github.com/dickenhobelix/fack
 
 go 1.23.2
 


### PR DESCRIPTION
This allows to use go mod install and also some other tooling. Technically this may be somewhat incompatible to some of the previous releases, but since this tool is not published on pkg.go.dev, this should not be too bad.