### PR TITLE
CI: do not run goreleaser on each push

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -2,7 +2,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:


### PR DESCRIPTION
Since goreleaser always runs against the last tag, this causes a mismatch between tag and commit hash in the branch pushed. Remove the condition for now.